### PR TITLE
Add identifier and broadcast it upon updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,20 @@ Update Subscription
 
 Sometimes it is preferable to subscribe to the update of the Crossfilter, and to apply any modifications of your data at that point rather than relying on Angular's dirty-checking.
 
-In these cases you can listen to the `crossfilter/updated` event.
+In these cases you can listen to the `crossfilter/updated` event, which passes along the collection and the identifier of the Crossfilter.
 
 ```javascript
-$scope.$on('crossfilter/updated', function() {
+$scope.$on('crossfilter/updated', function(event, collection, identifier) {
 
     // Voila!
 
 });
+```
+
+The identifier is empty by default, but can be set at any point.
+
+```javascript
+$ngc.identifyAs('myCrossfilter');
 ```
 
 Bundled Filters

--- a/module/ngCrossfilter.js
+++ b/module/ngCrossfilter.js
@@ -179,6 +179,13 @@
             Service.prototype._deletedKeys = [];
 
             /**
+             * @property _identifier
+             * @type {String}
+             * @private
+             */
+            Service.prototype._identifier = '';
+
+            /**
              * List of common filters bundled into ngCrossfilter.
              *
              * @property filters
@@ -933,7 +940,7 @@
              * @return {void}
              */
             Service.prototype.broadcastEvent = function broadcastEvent() {
-                $rootScope.$broadcast('crossfilter/updated', this.collection());
+                $rootScope.$broadcast('crossfilter/updated', this.collection(), this._identifier);
             };
 
             /**
@@ -960,6 +967,15 @@
 
                 return this._dimensions[sortProperty][sortOrder](limit || Infinity);
 
+            };
+
+            /**
+             * @method identifyAs
+             * @param identifier {String}
+             * @return {void}
+             */
+            Service.prototype.identifyAs = function identifyAs(identifier) {
+                this._identifier = identifier;
             };
 
             /**

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -496,6 +496,19 @@ describe('ngCrossfilter', function() {
             expect(collection[4].value).toEqual(2);
         });
 
+        it('Should be able to broadcast its collection and identifier upon updates;', function() {
+            inject(function(Crossfilter) {
+                $service = new Crossfilter($collection);
+                expect($rootScope.$broadcast)
+                    .toHaveBeenCalledWith('crossfilter/updated', $service.collection(), '');
+
+                $service.identifyAs('myCrossfilter');
+                $service.sortBy('country');
+                expect($rootScope.$broadcast)
+                    .toHaveBeenCalledWith('crossfilter/updated', $service.collection(), 'myCrossfilter');
+            });
+        });
+
         describe('Bundled Filters', function() {
 
             it('Should be able to use the fuzzy filter;', function() {


### PR DESCRIPTION
This change provides a straightforward way to identify which Crossfilter triggered an update.

This should be backwards-compatible unless someone is relying on the the update event to pass along only one argument, which is a bit far-fetched.

closes #18 