### PR TITLE
Add methods to toggle the broadcasting of the updated event

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ The identifier is empty by default, but can be set at any point.
 $ngc.identifyAs('myCrossfilter');
 ```
 
+It is possible to disable and re-enable the broadcasting of the `crossfilter/updated` event. For example, the following would broadcast a single event.
+
+```javascript
+$ngc.disableBroadcastEvent();
+$ngc.sortBy('population');
+$ngc.unfilterBy('city');
+
+$ngc.enableBroadcastEvent();
+$ngc.filterBy('climate', [5, 10]);
+```
+
+If you need full control over when the event is triggered, you may disable the event as described above and broadcast it yourself.
+
+```javascript
+$service.broadcastEvent(true);
+```
+
 Bundled Filters
 -------------
 

--- a/module/ngCrossfilter.js
+++ b/module/ngCrossfilter.js
@@ -49,7 +49,7 @@
      */
     ngCrossfilter.service('Crossfilter', ['$rootScope', '$timeout', '$window',
 
-        /*jshint maxstatements: 55 */
+        /*jshint maxstatements: 60 */
         function CrossfilterService($rootScope, $timeout, $window) {
 
             /**
@@ -184,6 +184,14 @@
              * @private
              */
             Service.prototype._identifier = '';
+
+            /**
+             * @property _isBroadcastEventEnabled
+             * @type {Boolean}
+             * @default true
+             * @private
+             */
+            Service.prototype._isBroadcastEventEnabled = true;
 
             /**
              * List of common filters bundled into ngCrossfilter.
@@ -937,10 +945,29 @@
 
             /**
              * @method broadcastEvent
+             * @param force {Boolean}
              * @return {void}
              */
-            Service.prototype.broadcastEvent = function broadcastEvent() {
-                $rootScope.$broadcast('crossfilter/updated', this.collection(), this._identifier);
+            Service.prototype.broadcastEvent = function broadcastEvent(force) {
+                if (this._isBroadcastEventEnabled || force === true) {
+                    $rootScope.$broadcast('crossfilter/updated', this.collection(), this._identifier);
+                }
+            };
+
+            /**
+             * @method enableBroadcastEvent
+             * @return {void}
+             */
+            Service.prototype.enableBroadcastEvent = function enableBroadcastEvent() {
+                this._isBroadcastEventEnabled = true;
+            };
+
+            /**
+             * @method disableBroadcastEvent
+             * @return {void}
+             */
+            Service.prototype.disableBroadcastEvent = function disableBroadcastEvent() {
+                this._isBroadcastEventEnabled = false;
             };
 
             /**

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -509,6 +509,35 @@ describe('ngCrossfilter', function() {
             });
         });
 
+        it('Should be able to toggle the broadcasting of the updated event;', function() {
+            inject(function(Crossfilter) {
+                $service = new Crossfilter($collection);
+                expect($rootScope.$broadcast.calls.count()).toEqual(1);
+
+                $service.disableBroadcastEvent();
+                $service.sortBy('population');
+                expect($rootScope.$broadcast.calls.count()).toEqual(1);
+
+                $service.enableBroadcastEvent();
+                $service.filterBy('climate', [5, 10]);
+                expect($rootScope.$broadcast.calls.count()).toEqual(2);
+            });
+        });
+
+        it('Should be able to force the broadcasting of the updated event;', function() {
+            inject(function(Crossfilter) {
+                $service = new Crossfilter($collection);
+                expect($rootScope.$broadcast.calls.count()).toEqual(1);
+
+                $service.disableBroadcastEvent();
+                $service.broadcastEvent();
+                expect($rootScope.$broadcast.calls.count()).toEqual(1);
+
+                $service.broadcastEvent(true);
+                expect($rootScope.$broadcast.calls.count()).toEqual(2);
+            });
+        });
+
         describe('Bundled Filters', function() {
 
             it('Should be able to use the fuzzy filter;', function() {


### PR DESCRIPTION
This change adds methods to disable and re-enable the broadcasting of the `crossfilter/updated` event. The default behaviour stays untouched, so this is a non-breaking change.

The use case is to be able to apply multiple filters in batch while relying on the `crossfilter/updated` event to apply any modifications of the data. ~~At the moment, multiple events would trigger, causing a race condition.~~

A more general approach would be to write some kind of `apply` method that takes a bunch of actions and only broadcasts once at the end, but that feels non-trivial, so I thought this might do.