### PR TITLE
Bump crossfilter version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "angular": "~1.2.1",
-    "crossfilter": "~1.3.5",
+    "crossfilter2": "~1.3.14",
     "underscore": "~1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-crossfilter",
   "buildName": "ngCrossfilter",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Usual Angular.js style filtering and sorting with a twist of Crossfilter for improved performance.",
   "main": "dist/ng-crossfilter.js",
   "scripts": {


### PR DESCRIPTION
The old version of crossfilter is no longer supported by square.  This new version is actively supported.